### PR TITLE
add pycapnp dependency (Cap'n Proto wrapper)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(name='magnumSTL',
       author_email='marcell.vc@eecs.berkeley.edu',
       license='MIT',
       install_requires=[
+          'pycapnp',
           'funcy',
           'PyYAML',
           'lenses',


### PR DESCRIPTION
For someone new to MagnumSTL and who does not know about `capnproto`, it is not obvious which dependency to get for use of `capnp` in magnum/io.py. Adding an entry in `install_requires` is one solution.

I tried to make the commit message verbose for posterity, but I can rebase and shorten it if you want.